### PR TITLE
TF 2.0.0b1 => TF 2.0.0 (fix error)

### DIFF
--- a/keras_fsl/sequences/training/single/deterministic_sequence.py
+++ b/keras_fsl/sequences/training/single/deterministic_sequence.py
@@ -55,7 +55,7 @@ class DeterministicSequence(AbstractSequence):
             self.preprocessings[0].augment_images(self.load_img(self.annotations[0].iloc[start_index:end_index])),
             axis=0,
         )]
-        output = [self.targets.iloc[start_index:end_index].values]
+        output = [self.targets.iloc[start_index:end_index].values.astype("float32")]
         if self.labels_in_input:
             inputs += output
         if not self.labels_in_output:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ imgaug==0.3.0
 numpy==1.16.4
 pandas==0.25.3
 PyYAML==5.1.2
-tensorboard==2.0.0
-tensorflow-gpu==2.0.0b1
+tensorflow-gpu==2.0.0
 gast==0.2.2


### PR DESCRIPTION
Ce qui empechait d'utiliser tensorflow==2.0.0, c'est que les labels issus de la dataframe etaient en uint8, et il n'arrivait pas a effectuer le calcul de la loss a cause de ca. En castant les labels en float, ca ne pose plus de problème.